### PR TITLE
official alpine images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,29 +15,38 @@ env:
   global:
     - BASEIMAGE=kylemanna/openvpn
     - VERSION=latest
+    - QEMU_VERSION=v2.9.1-1
   matrix:
-    - ARCH=amd64 FROM=alpine:latest IMAGE=$BASEIMAGE:latest-$VERSION
-    - ARCH=arm FROM=multiarch/alpine:armhf-v3.7 IMAGE=$BASEIMAGE:$ARCH-$VERSION
-    - ARCH=arm64 FROM=multiarch/alpine:arm64-v3.7 IMAGE=$BASEIMAGE:$ARCH-$VERSION
+    - ARCH=amd64		QEMU_ARCH=x86_64
+    - ARCH=arm32v6	QEMU_ARCH=arm
+    - ARCH=aarch64	QEMU_ARCH=aarch64
+
+matrix:
+  allow_failures:
+    - env:
+      - ARCH=arm32v6	QEMU_ARCH=arm
+      - ARCH=aarch64	QEMU_ARCH=aarch64
 
 before_install:
     - docker --version
-
+   
 install:
     - git clone https://github.com/docker-library/official-images.git official-images
 
 # Assist with ci test debugging:
 #   - DEBUG=1
 before_script:
-    - if [ $ARCH != 'amd64' ]; then docker run --rm --privileged multiarch/qemu-user-static:register --reset; fi
-    - image="$IMAGE"
-    - docker build --build-arg from="$FROM" -t "$image" .
-    - docker inspect "$image"
-    - docker run --rm "$image" openssl version
+    - IMAGE="$BASEIMAGE:$ARCH-$VERSION"
+    - FROM="$ARCH/alpine:latest"
+    - wget -qO- https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz | tar xvz 
+    - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    - docker build --build-arg from="$FROM" --build-arg QEMU_VERSION="$QEMU_VERSION" --build-arg QEMU_ARCH="$QEMU_ARCH" -t "$IMAGE" .
+    - docker inspect "$IMAGE"
+    - docker run --rm "$IMAGE" openssl version
 
 script:
-    - official-images/test/run.sh "$image"
-    - test/run.sh "$image"
+    - official-images/test/run.sh "$IMAGE"
+    - test/run.sh "$IMAGE"
 
 after_script:
     - docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 # Original credit: https://github.com/jpetazzo/dockvpn
 
 ARG from=alpine:latest
+
 # Smallest base image
 FROM $from
 
 LABEL maintainer="Kyle Manna <kyle@kylemanna.com>"
+
+ARG QEMU_ARCH 
+ENV QEMU_ARCH ${QEMU_ARCH:-x86_64}
+
+ADD qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
 
 # Testing: pamtester
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
@@ -13,6 +19,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/reposi
     cp /usr/share/zoneinfo/UTC /etc/localtime && \
     echo "UTC" > /etc/timezone && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
+
 
 # Needed by scripts
 ENV OPENVPN /etc/openvpn

--- a/hooks/build
+++ b/hooks/build
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-docker build --tag ${DOCKER_REPO}:amd64-${DOCKER_TAG} .
+QEMU_VERSION=v2.9.1-1
+
 
 docker run --rm --privileged multiarch/qemu-user-static:register --reset
-for ARCH in arm64 arm; do
-  if [[ $ARCH = 'arm' ]]; then
-    MULTIARCH='armhf'
-  else
-    MULTIARCH=$ARCH
-  fi
-  docker build --build-arg "from=multiarch/alpine:${MULTIARCH}-v3.7" \
+
+for i in amd64,x86_64 arm32v6,arm aarch64,aarch64; do
+  IFS=","; set -- $i; 
+  ARCH=$1
+  QEMU_ARCH=$2
+
+  curl -L https://github.com/multiarch/qemu-user-static/releases/download/${QEMU_VERSION}/x86_64_qemu-${QEMU_ARCH}-static.tar.gz 2>/dev/null | tar xvz 
+  docker build --build-arg from="$ARCH/alpine:latest" \
+               --build-arg QEMU_ARCH="$QEMU_ARCH" \
                --tag ${DOCKER_REPO}:${ARCH}-${DOCKER_TAG} .
+
 done

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,9 +1,25 @@
 #!/bin/bash
 
-curl -L https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64 -o ./manifest-tool
+curl -L https://github.com/estesp/manifest-tool/releases/download/v0.7.0/manifest-tool-linux-amd64 -o ./manifest-tool 2>/dev/null
 chmod +x ./manifest-tool
 
-./manifest-tool push from-args \
-  --platforms linux/amd64,linux/arm64,linux/arm \
-  --template ${DOCKER_REPO}:ARCH-${DOCKER_TAG} \
-  --target ${DOCKER_REPO}:${DOCKER_TAG}
+
+echo "image: ${DOCKER_REPO}:${DOCKER_TAG}" > manifest.yml
+echo "manifests:" >> manifest.yml
+
+for i in amd64,x86_64,amd64 arm32v6,arm,arm aarch64,aarch64,arm64; do
+  IFS=","; set -- $i; 
+  ARCH=$1
+  QEMU_ARCH=$2
+  DOC_ARCH=$3
+  cat  >> manifest.yml <<EOF
+  -
+    image: ${DOCKER_REPO}:${ARCH}-${DOCKER_TAG}
+    platform:
+      architecture: $DOC_ARCH
+      os: linux
+EOF
+done
+
+
+./manifest-tool push from-spec manifest.yml

--- a/hooks/push
+++ b/hooks/push
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-for ARCH in amd64 arm64 arm; do
+for i in amd64,x86_64 arm32v6,arm aarch64,aarch64; do
+  IFS=","; set -- $i; 
+  ARCH=$1
+  QEMU_ARCH=$2
+
   docker push ${DOCKER_REPO}:${ARCH}-${DOCKER_TAG}
 done

--- a/test/tests/basic/run.sh
+++ b/test/tests/basic/run.sh
@@ -12,9 +12,9 @@ ip addr ls
 SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::' | head -n1)
 docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_genconfig -u udp://$SERV_IP
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'

--- a/test/tests/client/container.sh
+++ b/test/tests/client/container.sh
@@ -42,9 +42,9 @@ ovpn_genconfig \
     -u udp://$SERV_IP \
     -m 1337 \
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'

--- a/test/tests/dual-proto/run.sh
+++ b/test/tests/dual-proto/run.sh
@@ -15,9 +15,9 @@ SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::'
 # get temporary TCP config
 docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_genconfig -u tcp://$SERV_IP:443
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'

--- a/test/tests/iptables/run.sh
+++ b/test/tests/iptables/run.sh
@@ -11,9 +11,9 @@ SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::'
 docker volume create --name $OVPN_DATA
 docker run --rm -v $OVPN_DATA:/etc/openvpn $IMG ovpn_genconfig -u udp://$SERV_IP -N
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'

--- a/test/tests/otp/run.sh
+++ b/test/tests/otp/run.sh
@@ -20,9 +20,9 @@ docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG ovpn_genconfig -u udp://$SERV_IP
 # Ensure reneg-sec 0 in server config when two factor is enabled
 docker run -v $OVPN_DATA:/etc/openvpn --rm $IMG cat /etc/openvpn/openvpn.conf | grep 'reneg-sec 0' || abort 'reneg-sec not set to 0 in server config'
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'

--- a/test/tests/paranoid/container.sh
+++ b/test/tests/paranoid/container.sh
@@ -6,11 +6,11 @@ SERV_IP=$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::'
 #
 # Generate a simple configuration, returns nonzero on error
 #
-ovpn_genconfig -u udp://$SERV_IP 2>/dev/null
+ovpn_genconfig -u udp://$SERV_IP 
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'
@@ -23,7 +23,7 @@ export EASYRSA_REQ_CN="Travis-CI Test CA"
 #
 # Initialize the certificate PKI state, returns nonzero on error
 #
-ovpn_initpki nopass 2>/dev/null
+ovpn_initpki nopass 
 
 #
 # Test back-up

--- a/test/tests/revocation/run.sh
+++ b/test/tests/revocation/run.sh
@@ -17,9 +17,9 @@ SERV_IP="$(ip -4 -o addr show scope global  | awk '{print $4}' | sed -e 's:/.*::
 docker volume create --name $OVPN_DATA
 docker run --rm -v $OVPN_DATA:/etc/openvpn $IMG ovpn_genconfig -u udp://$SERV_IP
 
-if [[ $ARCH = 'arm' ]]; then
+if [[ $ARCH = 'arm32v6' ]]; then
   RSA_KEY_SIZE='512'
-elif [[ $ARCH = 'arm64' ]]; then
+elif [[ $ARCH = 'aarch64' ]]; then
   RSA_KEY_SIZE='1024'
 else
   RSA_KEY_SIZE='2048'


### PR DESCRIPTION
This PR change the base image from multiarch/alpine to the official ones: `amd64/alpine`, `arm32v6/alpine` and `aarch64/alpine`

You only needs to add the qemu-$ARCH-static to the /usr/bin folder to build the image in a X86 machine